### PR TITLE
Add field in package.json for es module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.0.0",
   "description": "Individual HTML helper functions for the snabbdom library",
   "main": "dist/index.js",
+  "module": "src/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "build": "babel './src/index.js' --out-file './dist/index.js'",
     "test": "mocha --compilers js:babel-register './src/**/test.js'",


### PR DESCRIPTION
See https://github.com/rollup/rollup/wiki/jsnext:main

This allows for tree-shaking optimization and direct compatibility with Rollup without requiring a plugin.